### PR TITLE
fix: prefix RSA encode bytes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,7 +24,7 @@
     // original project's identity. Thus it is recommended to leave the comment
     // on the following line intact, so that it shows up in code reviews that
     // modify the field.
-    .fingerprint = 0x20d91db40f8d0922,
+    .fingerprint = 0x20d91db4f12472bc,
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
@@ -37,8 +37,8 @@
     // internet connectivity.
     .dependencies = .{
         .zmultiformats = .{
-            .url = "git+https://github.com/zen-eth/multiformats-zig#92c90226ee8b14052718df724a1bc753996a6e07",
-            .hash = "zmultiformats-0.1.0-U2uyh94UBQCwBOXy5xZ9SZQJkQXZSiYCudWPWxNqjuE0",
+            .url = "git+https://github.com/zen-eth/multiformats-zig#1359ac3ab12a6af173c2b7f13ae9c4f5ff34e11e",
+            .hash = "zmultiformats-0.1.0-yjvchlEaBQCuIiXU5ScwglKjcfv9KxWERFPuriP7ReZs",
         },
         .gremlin = .{
             .url = "git+https://github.com/octopus-foundation/gremlin.zig#fccfe2659f24497199d86404e0ef7dbc79e033d2",

--- a/src/id.zig
+++ b/src/id.zig
@@ -47,8 +47,18 @@ pub const PeerId = struct {
     /// For keys <= 42 bytes, uses identity multihash
     /// For larger keys, uses SHA2-256 hash
     pub fn fromPublicKey(allocator: Allocator, public_key: *keys.PublicKey) !Self {
-        const protobuf_public_key = try public_key.encode(allocator);
+        var protobuf_public_key = try public_key.encode(allocator);
         defer allocator.free(protobuf_public_key);
+
+        if (public_key.type == .RSA) {
+            // RSA is the default key type (0) so the encoder omits it. Append the tag/value to
+            // match other implementations when hashing protobuf-encoded keys.
+            const type_field = [_]u8{ 0x08, 0x00 };
+            const augmented = try std.mem.concat(allocator, u8, &.{ &type_field, protobuf_public_key });
+            allocator.free(protobuf_public_key);
+            protobuf_public_key = augmented;
+        }
+
         if (protobuf_public_key.len <= MAX_INLINE_KEY_LENGTH) {
             // Use identity multihash for small keys
             const mh = try Multihash(64).wrap(MULTIHASH_IDENTITY_CODE, protobuf_public_key);

--- a/src/id.zig
+++ b/src/id.zig
@@ -53,9 +53,12 @@ pub const PeerId = struct {
         if (public_key.type == .RSA) {
             // RSA is the default key type (0) so the encoder omits it. Append the tag/value to
             // match other implementations when hashing protobuf-encoded keys.
-            const type_field = [_]u8{ 0x08, 0x00 };
-            const augmented = try std.mem.concat(allocator, u8, &.{ &type_field, protobuf_public_key });
-            allocator.free(protobuf_public_key);
+            const augmented = blk: {
+                const type_field = [_]u8{ 0x08, 0x00 };
+                const original = protobuf_public_key;
+                defer allocator.free(original);
+                break :blk try std.mem.concat(allocator, u8, &.{ &type_field, original });
+            };
             protobuf_public_key = augmented;
         }
 


### PR DESCRIPTION
This PR help fix zig/rust/go protobuf encoding difference, zig omits the value 0. It makes the peerid calculation inconsistent with rust/go when using RSA key. 

This could be improved when we forked and changed the gremin protobuf lib.